### PR TITLE
*: thread-safe regexp without locks

### DIFF
--- a/chelper.h
+++ b/chelper.h
@@ -1,14 +1,14 @@
 #include <oniguruma.h>
 
 extern int NewOnigRegex( char *pattern, int pattern_length, int option,
-                                  OnigRegex *regex, OnigRegion **region, OnigEncoding *encoding, OnigErrorInfo **error_info, char **error_buffer);
+                                  OnigRegex *regex, OnigEncoding *encoding, OnigErrorInfo **error_info, char **error_buffer);
 
 extern int SearchOnigRegex( void *str, int str_length, int offset, int option,
-                                  OnigRegex regex, OnigRegion *region, OnigErrorInfo *error_info, char *error_buffer, int *captures, int *numCaptures);
+                                  OnigRegex regex, OnigErrorInfo *error_info, char *error_buffer, int *captures, int *numCaptures);
 
 extern int MatchOnigRegex( void *str, int str_length, int offset, int option,
-                  OnigRegex regex, OnigRegion *region);
+                  OnigRegex regex);
 
-extern int LookupOnigCaptureByName(char *name, int name_length, OnigRegex regex, OnigRegion *region);
+extern int LookupOnigCaptureByName(char *name, int name_length, OnigRegex regex);
 
 extern int GetCaptureNames(OnigRegex regex, void *buffer, int bufferSize, int* groupNumbers);

--- a/regex.go
+++ b/regex.go
@@ -216,10 +216,6 @@ func getCapture(b []byte, beg int, end int) []byte {
 
 func (re *Regexp) match(b []byte, n int, offset int) bool {
 	if n == 0 {
-		return true
-	}
-
-	if n == 0 {
 		b = []byte{0}
 	}
 

--- a/regex_test.go
+++ b/regex_test.go
@@ -529,7 +529,7 @@ type FindTest struct {
 }
 
 func (t FindTest) String() string {
-	return fmt.Sprintf("pat: %#q text: %#q", t.pat, t.text)
+	return fmt.Sprintf("pattern: %#q text: %#q", t.pat, t.text)
 }
 
 var findTests = []FindTest{


### PR DESCRIPTION
This PR solves any concurrency problem in the library (as far tested in a production cluster) solving several problems in the original problem.

